### PR TITLE
Add julia 0.5 travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
 Compat 0.8.0
-BufferedStreams 0.1.1
+BufferedStreams 0.2


### PR DESCRIPTION
This PR adds the 0.5 branch of Julia to the test suite. I was unsure if we wanted to restrict to version 0.5, or allow >= 0.4. If we want the former, I will add this (just remove the need for BaseTestNext & Compat). I also bump the version of BufferedStreams.

Cheers,
K
