### PR TITLE
Create Libz, Gzip, and Raw stream types

### DIFF
--- a/src/Libz.jl
+++ b/src/Libz.jl
@@ -2,8 +2,12 @@ __precompile__()
 
 module Libz
 
-export ZlibInflateInputStream, ZlibDeflateInputStream,
+export GzipInflateInputStream, GzipDeflateInputStream,
+       RawInflateInputStream, RawDeflateInputStream,
+       ZlibInflateInputStream, ZlibDeflateInputStream,
+       GzipInflateOutputStream, GzipDeflateOutputStream,
        ZlibInflateOutputStream, ZlibDeflateOutputStream,
+       RawInflateOutputStream, RawDeflateOutputStream,
        adler32, crc32
 
 using BufferedStreams, Compat

--- a/src/sink.jl
+++ b/src/sink.jl
@@ -40,19 +40,43 @@ end
 """
     ZlibInflateOutputStream(output[; <keyword arguments>])
 
+Construct a zlib inflate output stream to decompress zlib data.
+
+# Arguments
+* `output`: a byte vector, IO object, or BufferedInputStream to which decompressed data should be written.
+* `bufsize::Integer=8192`: input and output buffer size.
+"""
+function ZlibInflateOutputStream(output; bufsize::Integer=8192)
+    return BufferedOutputStream(InflateSink(output, bufsize, false, false), bufsize)
+end
+
+
+"""
+    GzipInflateOutputStream(output[; <keyword arguments>])
+
 Construct a zlib inflate output stream to decompress gzip/zlib data.
 
 # Arguments
 * `output`: a byte vector, IO object, or BufferedInputStream to which decompressed data should be written.
 * `bufsize::Integer=8192`: input and output buffer size.
-* `raw::Bool=false`: if true, data is raw compress data, without zlib metadata
-* `gzip::Bool=true`: if true, data is gzip compressed; if false, zlib compressed.
 """
-function ZlibInflateOutputStream(output; bufsize::Integer=8192, raw::Bool=false,
-                                 gzip::Bool=true)
-    return BufferedOutputStream(InflateSink(output, bufsize, raw, gzip), bufsize)
+function GzipInflateOutputStream(output; bufsize::Integer=8192)
+    return BufferedOutputStream(InflateSink(output, bufsize, false, true), bufsize)
 end
 
+
+"""
+    RawInflateOutputStream(output[; <keyword arguments>])
+
+Construct a zlib inflate output stream to decompress raw deflate data.
+
+# Arguments
+* `output`: a byte vector, IO object, or BufferedInputStream to which decompressed data should be written.
+* `bufsize::Integer=8192`: input and output buffer size.
+"""
+function RawInflateOutputStream(output; bufsize::Integer=8192)
+    return BufferedOutputStream(InflateSink(output, bufsize, true, false), bufsize)
+end
 
 # deflate sink constructors
 # -------------------------
@@ -89,26 +113,68 @@ end
 """
     ZlibDeflateOutputStream(output[; <keyword arguments>])
 
-Construct a zlib deflate output stream to compress gzip/zlib data.
+Construct a zlib deflate output stream to compress zlib data.
 
 # Arguments
 * `output`: a byte vector, IO object, or BufferedInputStream to which compressed data should be written.
 * `bufsize::Integer=8192`: input and output buffer size.
-* `raw::Bool=false`: if true, data is raw compress data, without zlib metadata
-* `gzip::Bool=true`: if true, data is gzip compressed; if false, zlib compressed.
 * `level::Integer=6`: compression level in 1-9.
 * `mem_level::Integer=8`: memory to use for compression in 1-9.
 * `strategy=Z_DEFAULT_STRATEGY`: compression strategy; see zlib documentation.
 """
 function ZlibDeflateOutputStream(output;
                                  bufsize::Integer=8192,
-                                 raw::Bool=false,
-                                 gzip::Bool=true,
                                  level::Integer=6,
                                  mem_level::Integer=8,
                                  strategy=Z_DEFAULT_STRATEGY)
     return BufferedOutputStream(
-        DeflateSink(output, bufsize, raw, gzip, level, mem_level, strategy),
+        DeflateSink(output, bufsize, false, false, level, mem_level, strategy),
+        bufsize)
+end
+
+
+"""
+    GzipDeflateOutputStream(output[; <keyword arguments>])
+
+Construct a zlib deflate output stream to compress gzip data.
+
+# Arguments
+* `output`: a byte vector, IO object, or BufferedInputStream to which compressed data should be written.
+* `bufsize::Integer=8192`: input and output buffer size.
+* `level::Integer=6`: compression level in 1-9.
+* `mem_level::Integer=8`: memory to use for compression in 1-9.
+* `strategy=Z_DEFAULT_STRATEGY`: compression strategy; see zlib documentation.
+"""
+function GzipDeflateOutputStream(output;
+                                 bufsize::Integer=8192,
+                                 level::Integer=6,
+                                 mem_level::Integer=8,
+                                 strategy=Z_DEFAULT_STRATEGY)
+    return BufferedOutputStream(
+        DeflateSink(output, bufsize, false, true, level, mem_level, strategy),
+        bufsize)
+end
+
+
+"""
+    RawDeflateOutputStream(output[; <keyword arguments>])
+
+Construct a zlib deflate output stream to compress raw deflate data.
+
+# Arguments
+* `output`: a byte vector, IO object, or BufferedInputStream to which compressed data should be written.
+* `bufsize::Integer=8192`: input and output buffer size.
+* `level::Integer=6`: compression level in 1-9.
+* `mem_level::Integer=8`: memory to use for compression in 1-9.
+* `strategy=Z_DEFAULT_STRATEGY`: compression strategy; see zlib documentation.
+"""
+function RawDeflateOutputStream(output; 
+                                bufsize::Integer=8192,
+                                level::Integer=6, 
+                                mem_level::Integer=8, 
+                                strategy=Z_DEFAULT_STRATEGY)
+    return BufferedOutputStream(
+        DeflateSink(output, bufsize, true, false, level, mem_level, strategy),
         bufsize)
 end
 

--- a/src/source.jl
+++ b/src/source.jl
@@ -44,22 +44,53 @@ end
 """
     ZlibInflateInputStream(input[; <keyword arguments>])
 
-Construct a zlib inflate input stream to decompress gzip/zlib data.
+Construct a zlib inflate input stream to decompress gzip data.
 
 # Arguments
 * `input`: a byte vector, IO object, or BufferedInputStream containing compressed data to inflate.
 * `bufsize::Integer=8192`: input and output buffer size.
-* `raw::Bool=falso`: if true, data is raw compress data, without zlib metadata
-* `gzip::Bool=true`: if true, data is gzip compressed; if false, zlib compressed.
 * `reset_on_end::Bool=true`: on stream end, try to find the start of another stream.
 """
-function ZlibInflateInputStream(input; bufsize::Integer=8192, raw::Bool=false,
-                                gzip::Bool=true, reset_on_end::Bool=true)
+function ZlibInflateInputStream(input; bufsize::Integer=8192, 
+                                reset_on_end::Bool=true)
     return BufferedInputStream(
-        InflateSource(input, bufsize, raw, gzip, reset_on_end),
+        InflateSource(input, bufsize, false, false, reset_on_end),
         bufsize)
 end
 
+
+"""
+    GzipInflateInputStream(input[; <keyword arguments>])
+
+Construct a zlib inflate input stream to decompress gzip data.
+
+# Arguments
+* `input`: a byte vector, IO object, or BufferedInputStream containing compressed data to inflate.
+* `bufsize::Integer=8192`: input and output buffer size.
+* `reset_on_end::Bool=true`: on stream end, try to find the start of another stream.
+"""
+function GzipInflateInputStream(input; bufsize::Integer=8192, 
+                                reset_on_end::Bool=true)
+    return BufferedInputStream(
+        InflateSource(input, bufsize, false, true, reset_on_end), bufsize)
+end
+
+
+"""
+    RawInflateInputStream(input[; <keyword arguments>])
+
+Construct a zlib inflate input stream to decompress raw deflate data.
+
+# Arguments
+* `input`: a byte vector, IO object, or BufferedInputStream containing compressed data to inflate.
+* `bufsize::Integer=8192`: input and output buffer size.
+* `reset_on_end::Bool=true`: on stream end, try to find the start of another stream.
+"""
+function RawInflateInputStream(input; bufsize::Integer=8192, 
+                               reset_on_end::Bool=true)
+    return BufferedInputStream(
+        InflateSource(input, bufsize, true, false, reset_on_end), bufsize)
+end
 
 # deflate source constructors
 # ---------------------------
@@ -98,26 +129,67 @@ end
 """
     ZlibDeflateInputStream(input[; <keyword arguments>])
 
-Construct a zlib deflate input stream to compress gzip/zlib data.
+Construct a zlib deflate input stream to compress zlib data.
 
 # Arguments
 * `input`: a byte vector, IO object, or BufferedInputStream containing data to compress.
 * `bufsize::Integer=8192`: input and output buffer size.
-* `raw::Bool=false`: if true, data is raw compress data, without zlib metadata
-* `gzip::Bool=true`: if true, data is gzip compressed; if false, zlib compressed.
 * `level::Integer=6`: compression level in 1-9.
 * `mem_level::Integer=8`: memory to use for compression in 1-9.
 * `strategy=Z_DEFAULT_STRATEGY`: compression strategy; see zlib documentation.
 """
 function ZlibDeflateInputStream(input;
                                 bufsize::Integer=8192,
-                                raw::Bool=false,
-                                gzip::Bool=true,
                                 level::Integer=6,
                                 mem_level::Integer=8,
                                 strategy=Z_DEFAULT_STRATEGY)
     return BufferedInputStream(
-        DeflateSource(input, bufsize, raw, gzip, level, mem_level, strategy),
+        DeflateSource(input, bufsize, false, false, level, mem_level, strategy),
+        bufsize)
+end
+
+
+"""
+    GzipDeflateInputStream(input[; <keyword arguments>])
+
+Construct a zlib deflate input stream to compress gzip data.
+
+# Arguments
+* `input`: a byte vector, IO object, or BufferedInputStream containing data to compress.
+* `bufsize::Integer=8192`: input and output buffer size.
+* `level::Integer=6`: compression level in 1-9.
+* `mem_level::Integer=8`: memory to use for compression in 1-9.
+* `strategy=Z_DEFAULT_STRATEGY`: compression strategy; see zlib documentation.
+"""
+function GzipDeflateInputStream(input;
+                                bufsize::Integer=8192,
+                                level::Integer=6,
+                                mem_level::Integer=8,
+                                strategy=Z_DEFAULT_STRATEGY)
+    return BufferedInputStream(
+        DeflateSource(input, bufsize, false, true, level, mem_level, strategy),
+        bufsize)
+end
+
+
+"""
+    RawDeflateInputStream(input[; <keyword arguments>])
+
+Construct a zlib deflate input stream to compress raw deflate data.
+
+# Arguments
+* `input`: a byte vector, IO object, or BufferedInputStream containing data to compress.
+* `bufsize::Integer=8192`: input and output buffer size.
+* `level::Integer=6`: compression level in 1-9.
+* `mem_level::Integer=8`: memory to use for compression in 1-9.
+* `strategy=Z_DEFAULT_STRATEGY`: compression strategy; see zlib documentation.
+"""
+function RawDeflateInputStream(input; bufsize::Integer=8192, 
+                               level::Integer=6,
+                               mem_level::Integer=8, 
+                               strategy=Z_DEFAULT_STRATEGY)
+    return BufferedInputStream(
+        DeflateSource(input, bufsize, true, false, level, mem_level, strategy),
         bufsize)
 end
 


### PR DESCRIPTION
Pull request for issue #50. Replaces the `ZlibXYStream` API with:
```
{Zlib, Gzip, Raw}{Inflate, Deflate}{Input, Output}Stream
```
The three formats `Zlib`, `Gzip`, and `Raw` are the different wrapper types that [zlib](http://www.zlib.net/manual.html) supports.