### PR TITLE
Fix Julia 0.7 deprecations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.6
 Compat 0.27.0
 BufferedStreams 0.2.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/src/lowlevel.jl
+++ b/src/lowlevel.jl
@@ -1,4 +1,5 @@
 # Lower-level interface to the zlib library.
+import Compat: Cvoid
 
 if Compat.Sys.iswindows()
     const zlib = "zlib1"
@@ -59,7 +60,7 @@ const Z_DEFLATED = Cint(8)
 # ZStream
 # -------
 
-type ZStream
+mutable struct ZStream
     next_in::Ptr{UInt8}
     avail_in::Cuint
     total_in::Culong
@@ -69,11 +70,11 @@ type ZStream
     total_out::Culong
 
     msg::Ptr{UInt8}
-    state::Ptr{Void}
+    state::Ptr{Cvoid}
 
-    zalloc::Ptr{Void}
-    zfree::Ptr{Void}
-    opaque::Ptr{Void}
+    zalloc::Ptr{Cvoid}
+    zfree::Ptr{Cvoid}
+    opaque::Ptr{Cvoid}
 
     data_type::Cint
     adler::Culong

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using Libz
 
 using BufferedStreams, Compat
-using Base.Test
+using Compat.Test
+using Compat.Random
 
 srand(0x123456)
 
@@ -107,7 +108,7 @@ end
     @test_throws ArgumentError ZlibDeflateOutputStream(UInt8[], level=10)
     @test_throws ArgumentError ZlibInflateOutputStream(UInt8[], bufsize=0)
 
-    deflated = read(ZlibDeflateInputStream(Vector{UInt8}("foo")))
+    deflated = read(ZlibDeflateInputStream(Vector{UInt8}(codeunits("foo"))))
     buf = IOBuffer()
     out = ZlibInflateOutputStream(buf)
     BufferedStreams.writebytes(out, deflated, length(deflated), true)
@@ -174,7 +175,7 @@ end
 
 @testset "Concatenated gzip files" begin
     filepath = joinpath(dirname(@__FILE__), "foobar.txt.gz")
-    s = readstring(open(filepath) |> ZlibInflateInputStream)
+    s = read(open(filepath) |> ZlibInflateInputStream, String)
     @test s == "foo\nbar\n"
 end
 


### PR DESCRIPTION
# Fix remaining Julia 0.7 deprecations.
* `foldr(op, v0, itr)` → `foldr(op, itr, init = v0)`
* Get `Test` module from `Compat`.
* Get `srand` from `Compat.Random`.
* Convert `String` to `Vector{UInt8}` via `codeunits`.
* `readstring(io)` → `read(io, String)`
* `Void` → `Cvoid`
* `type` → `mutable struct`
* Convert parametric functions to `where` syntax.
* Drop support for Julia 0.5 in CI and REQUIRE.
