### PR TITLE
Backwards compatibility with 0.2 releases for zstream init functions

### DIFF
--- a/src/lowlevel.jl
+++ b/src/lowlevel.jl
@@ -282,3 +282,8 @@ function init_deflate_zstream(raw::Bool, gzip::Bool, level::Integer, mem_level::
     @zcheck init_deflate!(zstream, level, Z_DEFLATED, window_bits, mem_level, strategy)
     return zstream
 end
+
+# For backwards compatibility with 0.2 releases.
+init_inflate_zstream(gzip::Bool) = init_inflate_zstream(false, gzip)
+init_deflate_zstream(gzip::Bool, level::Integer, mem_level::Integer, strategy) =
+    init_deflate_zstream(false, gzip, level, mem_level, strategy)

--- a/src/sink.jl
+++ b/src/sink.jl
@@ -224,3 +224,26 @@ function reset!(sink::Sink{mode}) where mode
     )
     return sink
 end
+
+# For backwards compatibility with 0.2 releases.
+InflateSink(output::BufferedOutputStream, gzip::Bool) =
+    InflateSink(output, false, gzip)
+InflateSink(output::BufferedOutputStream, bufsize::Integer, gzip::Bool) =
+    InflateSink(output, bufsize, false, gzip)
+InflateSink(output::IO, bufsize::Integer, gzip::Bool) =
+    InflateSink(output, bufsize, false, gzip)
+InflateSink(output::Vector{UInt8}, bufsize::Integer, gzip::Bool) =
+    InflateSink(output, bufsize, false, gzip)
+
+DeflateSink(output::BufferedOutputStream, gzip::Bool, level::Integer,
+            mem_level::Integer, strategy) =
+    DeflateSink(output, false, gzip, level, mem_level, strategy)
+DeflateSink(output::BufferedOutputStream, bufsize::Integer,
+            gzip::Bool, level::Integer, mem_level::Integer, strategy) =
+    DeflateSink(output, bufsize, false, gzip, level, mem_level, strategy)
+DeflateSink(output::IO, bufsize::Integer, gzip::Bool, level::Integer,
+            mem_level::Integer, strategy) =
+    DeflateSink(output, bufsize, false, gzip::Bool, level, mem_level, strategy)
+DeflateSink(output::Vector{UInt8}, bufsize::Integer, gzip::Bool,
+            level::Integer, mem_level::Integer, strategy) =
+    DeflateSink(output, bufsize, false, gzip, level, mem_level, strategy)

--- a/src/source.jl
+++ b/src/source.jl
@@ -238,3 +238,28 @@ function reset!(source::Source{mode}) where mode
     )
     return source
 end
+
+# For backwards compatibility with 0.2 releases.
+InflateSource(input::BufferedInputStream, gzip::Bool, reset_on_end::Bool) =
+    InflateSource(input, false, gzip, reset_on_end)
+InflateSource(input::BufferedInputStream, bufsize::Integer, gzip::Bool,
+              reset_on_end::Bool) =
+    InflateSource(input, bufsize, false, gzip, reset_on_end)
+InflateSource(input::IO, bufsize::Integer, gzip::Bool, reset_on_end::Bool) =
+    InflateSource(input, bufsize, false, gzip, reset_on_end)
+InflateSource(input::Vector{UInt8}, bufsize::Integer, gzip::Bool,
+              reset_on_end::Bool) =
+    InflateSource(input, bufsize, false, gzip, reset_on_end)
+
+DeflateSource(input::BufferedInputStream, gzip::Bool, level::Integer,
+              mem_level::Integer, strategy) =
+    DeflateSource(input, false, gzip, level, mem_level, strategy)
+DeflateSource(input::BufferedInputStream, bufsize::Integer, gzip::Bool,
+              level::Integer, mem_level::Integer, strategy) =
+    DeflateSource(input, bufsize, false, gzip, level, mem_level, strategy)
+DeflateSource(input::IO, bufsize::Integer, gzip::Bool, level::Integer,
+              mem_level::Integer, strategy) =
+    DeflateSource(input, bufsize, false, gzip, level, mem_level, strategy)
+DeflateSource(input::Vector{UInt8}, bufsize::Integer, gzip::Bool,
+              level::Integer, mem_level::Integer, strategy) =
+    DeflateSource(input, bufsize, false, gzip, level, mem_level, strategy)


### PR DESCRIPTION
An attempt to fix compatibility problems with 0.2.x releases, which were made off a branch, but admittedly a bit of a stab in the dark.
